### PR TITLE
FRESNO-101 Add `-Wno-enum-compare-switch` to libprotoc build

### DIFF
--- a/aircore/CMakeLists.txt
+++ b/aircore/CMakeLists.txt
@@ -12,6 +12,7 @@ add_subdirectory(${at_media_deps_dir}/protobuf/cmake ${CMAKE_BINARY_DIR}/protobu
 # On Clang 9 (Starting Android NDK r21b) this is nesserary to compile.
 # (Error later seen on Xcode 12 too).
 target_compile_options(libprotobuf PRIVATE -Wno-enum-compare-switch)
+target_compile_options(libprotoc PRIVATE -Wno-enum-compare-switch)
 
 # On iOS and Android we need to make sure we use the host version of protoc to generate files
 set(PROTOBUF_PROTOC_EXECUTABLE "")


### PR DESCRIPTION
While we had already added `-Wno-enum-compare-switch` switch to `libprotobuf`, it is added with the CMake visibility specified `PRIVATE`. This means when `libprotoc` incorporates `libprotobuf` into it's build it doesn't see this compile flag. We don't want to make it `PUBLIC`, so we can just add the flag to `libprotoc` in the same place.

This was mainly to let `huron` build. I believe that `libprotoc` is used in `visqol` which is a dependency of `huron`.

This needs to get merged first, and then once merged, we can update the submodule commit in `huron`.