### PR TITLE
CAR-2521 Use CMP0156 to handle duplicate libraries in link lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ if(POLICY CMP0141)
   cmake_policy(SET CMP0141 OLD)
 endif()
 
+# airtime: start - CAR-2521 Use CMP0156 to handle duplicate libraries in link lines
+cmake_policy(SET CMP0156 NEW)
+# airtime: end
+
 if(protobuf_VERBOSE)
   message(STATUS "Protocol Buffers Configuring...")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,6 @@ if(POLICY CMP0141)
   cmake_policy(SET CMP0141 OLD)
 endif()
 
-# airtime: start - CAR-2521 Use CMP0156 to handle duplicate libraries in link lines
-# cmake_policy(SET CMP0156 NEW)
-# airtime: end
-
 if(protobuf_VERBOSE)
   message(STATUS "Protocol Buffers Configuring...")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(POLICY CMP0141)
 endif()
 
 # airtime: start - CAR-2521 Use CMP0156 to handle duplicate libraries in link lines
-cmake_policy(SET CMP0156 NEW)
+# cmake_policy(SET CMP0156 NEW)
 # airtime: end
 
 if(protobuf_VERBOSE)

--- a/aircore/CMakeLists.txt
+++ b/aircore/CMakeLists.txt
@@ -1,6 +1,7 @@
 # build libprotobuf
 cmake_policy(SET CMP0079 NEW)
 cmake_policy(SET CMP0077 NEW)
+cmake_policy(SET CMP0156 NEW)  # CAR-2521 Use CMP0156 to handle duplicate libraries in link lines
 
 set(protobuf_ABSL_PROVIDER "none" CACHE STRING "")
 add_subdirectory_once(${at_media_deps_dir}/abseil-cpp ${CMAKE_BINARY_DIR}/abseil-cpp)

--- a/aircore/CMakeLists.txt
+++ b/aircore/CMakeLists.txt
@@ -1,7 +1,6 @@
 # build libprotobuf
 cmake_policy(SET CMP0079 NEW)
 cmake_policy(SET CMP0077 NEW)
-cmake_policy(SET CMP0156 NEW)  # CAR-2521 Use CMP0156 to handle duplicate libraries in link lines
 
 set(protobuf_ABSL_PROVIDER "none" CACHE STRING "")
 add_subdirectory_once(${at_media_deps_dir}/abseil-cpp ${CMAKE_BINARY_DIR}/abseil-cpp)


### PR DESCRIPTION
**Issue:** When building protobuf, two linker warnings related to duplicate libraries appear toward the end of the process on macOS

**Root Cause:**
- Platform-Specific Issue: The warnings are only seen on macOS but not on Linux (verified using Jenkins workers).
- New Apple Linker: With the Xcode 15 update, Apple introduced a new linker aimed at speeding up static linking. This new linker automatically re-scans static libraries, meaning repeated static libraries in the link line are unnecessary. However, the older classic linker (-ld64) does require repeated libraries.

**Solution:**
- CMake Fix: CMake version 3.29.0 and above resolves this by de-duplicating libraries in link lines based on the linker’s capabilities. It ensures that static libraries are listed only once in the link line for platforms like macOS, where repeated libraries are no longer needed. CMake applies this through policy CMP0156.
- To enforce this, we’ve updated CMakeLists.txt to have `cmake_policy(SET CMP0156 NEW)`, ensuring that libraries are de-duplicated on supported platforms.

**Xcode 15 Release Notes:**
A new linker has been written to significantly speed up static linking. It’s the default for all macOS, iOS, tvOS, and visionOS binaries and anyone using the “Mergeable Libraries” feature. The classic linker can still be explicitly requested using -ld64, and will be removed in a future release.

**CMake 3.29.0 Release Notes:**
CMake learned to de-duplicate libraries on link lines based on linker capabilities. See policy CMP0156.
This policy was introduced in CMake version 3.29. It may be set by cmake_policy() or cmake_minimum_required().