### PR TITLE
CAR-2615 Suppress protobuf Xcode 26.4 warning

### DIFF
--- a/aircore/CMakeLists.txt
+++ b/aircore/CMakeLists.txt
@@ -13,6 +13,9 @@ add_subdirectory(${at_media_deps_dir}/protobuf/cmake ${CMAKE_BINARY_DIR}/protobu
 # (Error later seen on Xcode 12 too).
 target_compile_options(libprotobuf PRIVATE -Wno-enum-compare-switch)
 
+# Newer AppleClang diagnoses descriptor.cc's legacy memset pattern.
+target_compile_options(libprotobuf PRIVATE -Wno-nontrivial-memcall)
+
 # We don't build libprotoc for android or ios
 if (TARGET libprotoc)
   target_compile_options(libprotoc PRIVATE -Wno-enum-compare-switch)


### PR DESCRIPTION
AppleClang from Xcode 26.4 reports -Wnontrivial-memcall in protobuf's legacy descriptor.cc memset pattern. The warning is promoted to an error by the existing build flags, which prevents local Carmel unit-test builds from completing with OSX_SDK_OVERRIDE=macosx26.4.

Add the suppression in the Cantina-owned aircore CMake wrapper for libprotobuf only. This leaves upstream protobuf sources unchanged and keeps the temporary build fix separate from the planned protobuf 3.21.12 upgrade.